### PR TITLE
Documentation update post recent deployment

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "github.vscode-pull-request-github"
+    ]
+}

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -159,7 +159,7 @@ Control Plane Machines
 
           * If this is left blank, the network interface will be be configured by DHCP on every boot. A static IP assignement will be made on the DHCP server.
           * If a single NIC is configured (ex: eno5), after the first boot, the NIC will be configured to manually set the node's IP address without using DHCP.
-          * A network bond can be configured here using the sytax `NIC0,NIC1:MODE` (ex: eno4,eno4:balance-alb). In this situation, the IP address will be statically assigned and the bond will be configured. The node must still be able to boot using a single NIC in order to PXE boot. Configuring the backing network switching architecture to support bonding is out of scope of the installer. For the bonding mode, balance-rr, active-backup, balance-xor, broadcast, and 802.3ad are the only supported options.
+          * A network bond can be configured here using the sytax `NIC0,NIC1:MODE` (ex: eno4,eno4:balance-xor). In this situation, the IP address will be statically assigned and the bond will be configured. The node must still be able to boot using a single NIC in order to PXE boot. Configuring the backing network switching architecture to support bonding is out of scope of the installer. For the bonding mode, balance-rr, active-backup, balance-xor, broadcast, and 802.3ad are the only supported options.
 
       * *MAC Address*: The MAC address for the node's cluster connected NIC. In
         the case of a bond, this should be the MAC address of the first NIC in

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -32,6 +32,8 @@ configured for the installation to work.
 
 5. The hardware system clock must be properly set.
 
+6. Repeat for each node.
+
 These settings can be configured before starting the deployment or during. If
 you require access to the cluster nodes' out-of-band management interfaces to
 perform this configuration then wait until during the deployment. The

--- a/source/configuration.rst
+++ b/source/configuration.rst
@@ -242,3 +242,5 @@ Additional CA Bundle
     cluster during install so that HTTPS traffic will still be trusted. These
     public certs should be pasted here.
 
+Faros stores stateful configurations made above in `~/.config/faros/default` for 
+reference or backup.

--- a/source/installation.rst
+++ b/source/installation.rst
@@ -22,9 +22,6 @@ During install, the following details are important.
     before: :code:`bastion.CLUSTER_NAME.CLUSTER_DOMAIN`.
   - It is recomended to install the `RHEL Server without GUI` set of packages.
     In theory, any option that includes additional packages should also work.
-  - The primary drive used to install RHEL on the bastion node is the same
-    drive that will be used on all of the cluster nodes for RHCOS. Primary is
-    defined as the drive that contains the :code:`/boot` partition.
   - During install, it is best to setup a single user account that will be used
     for the cluster deployment. This user account should be an admin account
     with the ability to sudo.

--- a/source/storage.rst
+++ b/source/storage.rst
@@ -66,37 +66,3 @@ To enable cluster storage, use the following commands:
 
   oc patch configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec":{"storage":{"pvc":{"claim":""}}}}'
   oc patch configs.imageregistry.operator.openshift.io/cluster --type merge -p '{"spec":{"managementState":"Managed"}}'
-
-
-Enable registry pruning
------------------------
-
-Once the registry is enabled, image pruning should also be enabled to reduce
-clutter. To enable cluster storage, edit the
-:code:`imagepruner.imageregistry.operator.openshift.io/cluster` resource.
-
-.. code-block:: bash
-
-  oc edit imagepruner.imageregistry.operator.openshift.io/cluster
-
-The value for :code:`spec.suspended` should be set to *false*.
-
-After making this change, watch the operator status indicator on the
-OpenShift console. When the indicator goes green and doesn't show anymore
-cluster operators pending, the configuration change is complete.
-
-The :code:`imagepruner.imageregistry.operator.openshift.io/cluster` resource
-definition should look like the following.
-
-.. code-block:: yaml
-
-  apiVersion: imageregistry.operator.openshift.io/v1
-  kind: ImagePruner
-  metadata:
-    name: cluster
-  spec:
-    failedJobsHistoryLimit: 3
-    keepTagRevisions: 3
-    schedule: ""
-    successfulJobsHistoryLimit: 3
-    suspend: false


### PR DESCRIPTION
general documentation updates post successful deployment:


1. explicitly update each node individually
2. Updates A network bond can be configured here using the syntax NIC0,NIC1:MODE (ex: eno4,eno4:balance-alb) to -xor as alb doesn't work
3. Add less ~/.config/faros/default to Faros for modifying and backing up config file and keep configs in git
4. remove registry pruning